### PR TITLE
Register docxsphinx as builder through setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,4 +48,9 @@ setup(
      test_suite='nose.collector',
      tests_require=['Nose'],
      zip_safe=False,
+     entry_points={
+        'sphinx.builders': [
+            'docx=docxsphinx',
+        ],
+     }
 )


### PR DESCRIPTION
This means it is not necessary anymore to put it in the extensions in
conf.py. See https://github.com/sphinx-doc/sphinx/pull/2803

And that means that it is possible to build the html-version of the document without having the docxsphinx plugin installed.