### PR TITLE
remove unnecessary output

### DIFF
--- a/src/docxsphinx/writer.py
+++ b/src/docxsphinx/writer.py
@@ -46,6 +46,8 @@ def dprint(_func=None, **kw):
     if _func is None:
         _func = f.f_code.co_name
 
+    # It would be nice to have the non-kw dprints to be debug-level' issues,
+    # but that does not seem to work.
     if kw:
         logger.info(' '.join([_func, text]))
 

--- a/src/docxsphinx/writer.py
+++ b/src/docxsphinx/writer.py
@@ -35,7 +35,7 @@ logger = logging.getLogger('docx')
 
 def dprint(_func=None, **kw):
     """Print debug information."""
-    logger.info('-'*50)
+    #logger.info('-'*50)
     # noinspection PyProtectedMember
     f = sys._getframe(1)
     if kw:
@@ -47,7 +47,8 @@ def dprint(_func=None, **kw):
     if _func is None:
         _func = f.f_code.co_name
 
-    logger.info(' '.join([_func, text]))
+    if kw:
+        logger.info(' '.join([_func, text]))
 
 
 # noinspection PyUnusedLocal
@@ -162,12 +163,12 @@ class DocxTranslator(nodes.NodeVisitor):
         dprint()
         self.old_states.append(self.current_state)
         self.current_state = DocxState(location=location)
-        print("HB new_state: {}".format(len(self.old_states)))
+        #print("HB new_state: {}".format(len(self.old_states)))
 
     def end_state(self, first=None):
         dprint()
         self.current_state = self.old_states.pop()
-        print("HB old_state: {}".format(len(self.old_states)))
+        #print("HB old_state: {}".format(len(self.old_states)))
 
     def visit_start_of_file(self, node):
         dprint()
@@ -533,8 +534,8 @@ class DocxTranslator(nodes.NodeVisitor):
         dprint()
         colspecs = [c for c in node.children if isinstance(c, nodes.colspec)]
         self.current_state.ncolumns = len(colspecs)
-        print("HB VT {} {} {}".format(
-            self.current_state.ncolumns, len(node.children), [type(c) for c in node.children]))
+        #print("HB VT {} {} {}".format(
+        #    self.current_state.ncolumns, len(node.children), [type(c) for c in node.children]))
 
     def depart_tgroup(self, node):
         dprint()
@@ -703,20 +704,20 @@ class DocxTranslator(nodes.NodeVisitor):
                 if not curloc.paragraphs[0].text:
                     # An empty paragraph is created when a Cell is created.
                     # Reuse this paragraph.
-                    print("HB VLI reuse {}".format(style))
+                    #print("HB VLI reuse {}".format(style))
                     self.current_paragraph = curloc.paragraphs[0]
                     self.current_paragraph.style = style
                 else:
-                    print("HB VLI create 1 {}".format(style))
+                    #print("HB VLI create 1 {}".format(style))
                     self.current_paragraph = curloc.add_paragraph(style=style)
             else:
-                print("HB VLI create 2 {}".format(style))
+                #print("HB VLI create 2 {}".format(style))
                 self.current_paragraph = curloc.add_paragraph(style=style)
         else:
-            print("HB VLI create 3 {}".format(style))
+            #print("HB VLI create 3 {}".format(style))
             self.current_paragraph = curloc.add_paragraph(style=style)
 
-        print("HB VLI end {}".format(self.current_paragraph.style))
+        #print("HB VLI end {}".format(self.current_paragraph.style))
 
     def depart_list_item(self, node):
         dprint()
@@ -922,7 +923,7 @@ class DocxTranslator(nodes.NodeVisitor):
         curloc = self.current_state.location
 
         if 'List' in self.current_paragraph.style.name and not self.current_paragraph.text:
-            print("HB VP List")
+            #print("HB VP List")
             # This is the first paragraph in a list item, so do not create another one.
             pass
         elif isinstance(curloc, _Cell):
@@ -931,21 +932,21 @@ class DocxTranslator(nodes.NodeVisitor):
                     # An empty paragraph is created when a Cell is created.
                     # Reuse this paragraph.
                     self.current_paragraph = curloc.paragraphs[0]
-                    print("HB VP cell reuse")
+                    #print("HB VP cell reuse")
                 else:
                     self.current_paragraph = curloc.add_paragraph()
-                    print("HB VP cell create 1")
+                    #print("HB VP cell create 1")
             else:
                 self.current_paragraph = curloc.add_paragraph()
-                print("HB VP cell create 2")
+                #print("HB VP cell create 2")
             # HACK because the style is messed up, TODO FIX
             self.current_paragraph.paragraph_format.alignment = WD_ALIGN_PARAGRAPH.LEFT
             self.current_paragraph.paragraph_format.left_indent = 0
         else:
-            print("HB VP normal")
+            #print("HB VP normal")
             self.current_paragraph = curloc.add_paragraph()
 
-        print("HB VP end {}".format(self.current_paragraph.style))
+        #print("HB VP end {}".format(self.current_paragraph.style))
 
     def depart_paragraph(self, node):
         dprint()
@@ -1121,7 +1122,7 @@ class DocxTranslator(nodes.NodeVisitor):
         comment = node[0]
         if 'DocxTableStyle' in comment:
             self.current_state.table_style = comment.split('DocxTableStyle')[-1].strip()
-        print("HB tablestyle {}".format(self.current_state.table_style))
+        #print("HB tablestyle {}".format(self.current_state.table_style))
         raise nodes.SkipNode
 
     def visit_meta(self, node):

--- a/src/docxsphinx/writer.py
+++ b/src/docxsphinx/writer.py
@@ -35,7 +35,6 @@ logger = logging.getLogger('docx')
 
 def dprint(_func=None, **kw):
     """Print debug information."""
-    #logger.info('-'*50)
     # noinspection PyProtectedMember
     f = sys._getframe(1)
     if kw:
@@ -163,12 +162,10 @@ class DocxTranslator(nodes.NodeVisitor):
         dprint()
         self.old_states.append(self.current_state)
         self.current_state = DocxState(location=location)
-        #print("HB new_state: {}".format(len(self.old_states)))
 
     def end_state(self, first=None):
         dprint()
         self.current_state = self.old_states.pop()
-        #print("HB old_state: {}".format(len(self.old_states)))
 
     def visit_start_of_file(self, node):
         dprint()
@@ -534,8 +531,6 @@ class DocxTranslator(nodes.NodeVisitor):
         dprint()
         colspecs = [c for c in node.children if isinstance(c, nodes.colspec)]
         self.current_state.ncolumns = len(colspecs)
-        #print("HB VT {} {} {}".format(
-        #    self.current_state.ncolumns, len(node.children), [type(c) for c in node.children]))
 
     def depart_tgroup(self, node):
         dprint()
@@ -704,20 +699,14 @@ class DocxTranslator(nodes.NodeVisitor):
                 if not curloc.paragraphs[0].text:
                     # An empty paragraph is created when a Cell is created.
                     # Reuse this paragraph.
-                    #print("HB VLI reuse {}".format(style))
                     self.current_paragraph = curloc.paragraphs[0]
                     self.current_paragraph.style = style
                 else:
-                    #print("HB VLI create 1 {}".format(style))
                     self.current_paragraph = curloc.add_paragraph(style=style)
             else:
-                #print("HB VLI create 2 {}".format(style))
                 self.current_paragraph = curloc.add_paragraph(style=style)
         else:
-            #print("HB VLI create 3 {}".format(style))
             self.current_paragraph = curloc.add_paragraph(style=style)
-
-        #print("HB VLI end {}".format(self.current_paragraph.style))
 
     def depart_list_item(self, node):
         dprint()
@@ -923,7 +912,6 @@ class DocxTranslator(nodes.NodeVisitor):
         curloc = self.current_state.location
 
         if 'List' in self.current_paragraph.style.name and not self.current_paragraph.text:
-            #print("HB VP List")
             # This is the first paragraph in a list item, so do not create another one.
             pass
         elif isinstance(curloc, _Cell):
@@ -932,21 +920,15 @@ class DocxTranslator(nodes.NodeVisitor):
                     # An empty paragraph is created when a Cell is created.
                     # Reuse this paragraph.
                     self.current_paragraph = curloc.paragraphs[0]
-                    #print("HB VP cell reuse")
                 else:
                     self.current_paragraph = curloc.add_paragraph()
-                    #print("HB VP cell create 1")
             else:
                 self.current_paragraph = curloc.add_paragraph()
-                #print("HB VP cell create 2")
             # HACK because the style is messed up, TODO FIX
             self.current_paragraph.paragraph_format.alignment = WD_ALIGN_PARAGRAPH.LEFT
             self.current_paragraph.paragraph_format.left_indent = 0
         else:
-            #print("HB VP normal")
             self.current_paragraph = curloc.add_paragraph()
-
-        #print("HB VP end {}".format(self.current_paragraph.style))
 
     def depart_paragraph(self, node):
         dprint()
@@ -1122,7 +1104,6 @@ class DocxTranslator(nodes.NodeVisitor):
         comment = node[0]
         if 'DocxTableStyle' in comment:
             self.current_state.table_style = comment.split('DocxTableStyle')[-1].strip()
-        #print("HB tablestyle {}".format(self.current_state.table_style))
         raise nodes.SkipNode
 
     def visit_meta(self, node):


### PR DESCRIPTION
Most of the debug output is unnecessary and should be disabled